### PR TITLE
Add container for Right, Middle, and Left Columns, Main Navigation and Footer placeholders

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,9 @@
-import Image from "next/image";
 import AicureToolFull from "@/components/AicureToolFull";
 
 export default function Home() {
 	return (
 		<div>
-			<h1>Commit test for both urls</h1>
+			<h1>AI-Cure tool</h1>
 			<AicureToolFull />;
 		</div>
 	);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import AicureToolFull from "@/components/AicureToolFull";
 import MainNavigation from "@/components/MainNanigation";
+import Footer from "@/components/Footer";
 
 export default function Home() {
 	return (
@@ -7,6 +8,7 @@ export default function Home() {
 			<MainNavigation />
 			<h1>AI-Cure tool</h1>
 			<AicureToolFull />;
+			<Footer />
 		</div>
 	);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,10 @@
 import AicureToolFull from "@/components/AicureToolFull";
+import MainNavigation from "@/components/MainNanigation";
 
 export default function Home() {
 	return (
 		<div>
+			<MainNavigation />
 			<h1>AI-Cure tool</h1>
 			<AicureToolFull />;
 		</div>

--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -6,19 +6,16 @@ import MiddleTopColumn from "./MiddleTopColumn";
 import MiddleBottomColumn from "./MiddleBottomColumn";
 
 const AicureToolFull = () => {
-	// Only track right column visibility now
 	const [showRight, setShowRight] = useState(true);
 
 	const toggleRightColumn = () => setShowRight((prev) => !prev);
 
 	return (
 		<div className="flex h-screen p-2">
-			{/* Left Column (Always Visible) */}
 			<div className="w-1/4">
 				<LeftColumn />
 			</div>
 
-			{/* Middle Column (Adjusts width based on right column state) */}
 			<div className="flex flex-col h-screen flex-grow">
 				<div className="h-3/4">
 					<MiddleTopColumn />
@@ -28,7 +25,6 @@ const AicureToolFull = () => {
 				</div>
 			</div>
 
-			{/* Right Column (Collapses to small width when hidden) */}
 			<div className={`${showRight ? "w-1/4" : "w-10"} flex h-full`}>
 				<RightColumn
 					toggleRightColumn={toggleRightColumn}

--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -12,7 +12,7 @@ const AicureToolFull = () => {
 	const toggleRightColumn = () => setShowRight((prev) => !prev);
 
 	return (
-		<div className="flex h-screen p-2 gap-2">
+		<div className="flex h-screen p-2">
 			{/* Left Column (Always Visible) */}
 			<div className="w-1/4">
 				<LeftColumn />
@@ -29,15 +29,11 @@ const AicureToolFull = () => {
 			</div>
 
 			{/* Right Column (Collapses to small width when hidden) */}
-			<div className="flex-shrink-0">
-				<div
-					className={`${showRight ? "w-1/4" : "w-10"} flex items-start h-full`}
-				>
-					<RightColumn
-						toggleRightColumn={toggleRightColumn}
-						isRightColumnVisible={showRight}
-					/>
-				</div>
+			<div className={`${showRight ? "w-1/4" : "w-10"} flex h-full`}>
+				<RightColumn
+					toggleRightColumn={toggleRightColumn}
+					isRightColumnVisible={showRight}
+				/>
 			</div>
 		</div>
 	);

--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -12,16 +12,14 @@ const AicureToolFull = () => {
 	const toggleRightColumn = () => setShowRight((prev) => !prev);
 
 	return (
-		<div className="flex h-screen p-2">
+		<div className="flex h-screen p-2 gap-2">
 			{/* Left Column (Always Visible) */}
 			<div className="w-1/4">
 				<LeftColumn />
 			</div>
 
 			{/* Middle Column (Adjusts width based on right column state) */}
-			<div
-				className={`flex flex-col h-screen ${showRight ? "w-3/4" : "w-full"}`}
-			>
+			<div className="flex flex-col h-screen flex-grow">
 				<div className="h-3/4">
 					<MiddleTopColumn />
 				</div>
@@ -31,11 +29,15 @@ const AicureToolFull = () => {
 			</div>
 
 			{/* Right Column (Collapses to small width when hidden) */}
-			<div className={`${showRight ? "w-1/4" : "w-10"} flex items-start`}>
-				<RightColumn
-					toggleRightColumn={toggleRightColumn}
-					isRightColumnVisible={showRight}
-				/>
+			<div className="flex-shrink-0">
+				<div
+					className={`${showRight ? "w-1/4" : "w-10"} flex items-start h-full`}
+				>
+					<RightColumn
+						toggleRightColumn={toggleRightColumn}
+						isRightColumnVisible={showRight}
+					/>
+				</div>
 			</div>
 		</div>
 	);

--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -6,49 +6,37 @@ import MiddleTopColumn from "./MiddleTopColumn";
 import MiddleBottomColumn from "./MiddleBottomColumn";
 
 const AicureToolFull = () => {
-	const [showLeft, setShowLeft] = useState(true);
+	// Only track right column visibility now
 	const [showRight, setShowRight] = useState(true);
 
 	const toggleRightColumn = () => setShowRight((prev) => !prev);
+
 	return (
-		<div className="flex h-screen">
-			{/* Left Column */}
-			{showLeft && (
-				<div className="w-1/4">
-					<LeftColumn />
-					<button
-						onClick={() => setShowLeft(false)}
-						className="bg-gray-700 text-white p-1 mt-1 w-full"
-					></button>
-				</div>
-			)}
-			{/* Middle Columns */}
+		<div className="flex h-screen p-2">
+			{/* Left Column (Always Visible) */}
+			<div className="w-1/4">
+				<LeftColumn />
+			</div>
+
+			{/* Middle Column (Adjusts width based on right column state) */}
 			<div
-				className={`flex flex-col w-full h-screen" ${
-					showLeft && showRight
-						? "w-1/2"
-						: showLeft || showRight
-						? "w-3/4"
-						: "w-full"
-				}`}
+				className={`flex flex-col h-screen ${showRight ? "w-3/4" : "w-full"}`}
 			>
 				<div className="h-3/4">
-					<MiddleTopColumn
-						toggleRightColumn={toggleRightColumn}
-						isRightColumnVisible={showRight}
-					/>
+					<MiddleTopColumn />
 				</div>
 				<div className="flex-grow">
 					<MiddleBottomColumn />
 				</div>
 			</div>
 
-			{/* Right Column */}
-			{showRight && (
-				<div className="w-1/4">
-					<RightColumn />
-				</div>
-			)}
+			{/* Right Column (Collapses to small width when hidden) */}
+			<div className={`${showRight ? "w-1/4" : "w-10"} flex items-start`}>
+				<RightColumn
+					toggleRightColumn={toggleRightColumn}
+					isRightColumnVisible={showRight}
+				/>
+			</div>
 		</div>
 	);
 };

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,5 @@
+const Footer = () => {
+	return <footer>{/*Footer content goes here */}</footer>;
+};
+
+export default Footer;

--- a/src/components/MainNanigation.tsx
+++ b/src/components/MainNanigation.tsx
@@ -1,0 +1,9 @@
+const MainNavigation = () => {
+	return (
+		<div className="top-0">
+			<p> - Main Naviagation Place Holder - </p>
+		</div>
+	);
+};
+
+export default MainNavigation;

--- a/src/components/MainNanigation.tsx
+++ b/src/components/MainNanigation.tsx
@@ -1,7 +1,7 @@
 const MainNavigation = () => {
 	return (
 		<div className="top-0">
-			<p> - Main Naviagation Place Holder - </p>
+			<p>{/*Main Naviagation goes here*/}</p>
 		</div>
 	);
 };

--- a/src/components/MiddleTopColumn.tsx
+++ b/src/components/MiddleTopColumn.tsx
@@ -1,36 +1,7 @@
-import {
-	ChevronDoubleRightIcon,
-	ChevronDoubleLeftIcon,
-} from "@heroicons/react/24/outline";
-
-interface MiddleTopColumnProps {
-	toggleRightColumn: () => void;
-	isRightColumnVisible: boolean;
-}
-
-const MiddleTopColumn: React.FC<MiddleTopColumnProps> = ({
-	toggleRightColumn,
-	isRightColumnVisible,
-}) => {
+const MiddleTopColumn: React.FC = () => {
 	return (
 		<div className="bg-green-500 p-4 flex justify-between items-center h-full">
 			<p>Middle Top Column</p>
-			<button
-				onClick={toggleRightColumn}
-				className="bg-gray-700 text-white px-3 py-1 rounded flex items-center gap-2"
-			>
-				{isRightColumnVisible ? (
-					<>
-						<ChevronDoubleRightIcon className="h-5 w-5" />
-						Collapse Right Col
-					</>
-				) : (
-					<>
-						<ChevronDoubleLeftIcon className="h-5 w-5" />
-						Expand Right Col
-					</>
-				)}
-			</button>
 		</div>
 	);
 };

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -8,7 +8,7 @@ const RightColumn: React.FC<RightColumnProps> = ({
 	isRightColumnVisible,
 }) => {
 	return (
-		<div className="bg-red-500 flex flex-col items-start">
+		<div className="bg-red-500 flex flex-col items-start w-full">
 			{/* Toggle Button for Right Column */}
 			<button
 				onClick={toggleRightColumn}

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -1,7 +1,24 @@
-const RightColumn = () => {
+interface RightColumnProps {
+	toggleRightColumn: () => void;
+	isRightColumnVisible: boolean;
+}
+
+const RightColumn: React.FC<RightColumnProps> = ({
+	toggleRightColumn,
+	isRightColumnVisible,
+}) => {
 	return (
-		<div className="bg-red-500 p-4 h-full">
-			<p>Right Column</p>
+		<div className="bg-red-500 p-4 h-full flex items-start">
+			{/* Toggle Button for Right Column */}
+			<button
+				onClick={toggleRightColumn}
+				className="bg-gray-700 text-white p-2 rounded"
+			>
+				{isRightColumnVisible ? "→" : "←"}
+			</button>
+
+			{/* Show Right Column content only when expanded */}
+			{isRightColumnVisible && <p className="ml-2">Right Column</p>}
 		</div>
 	);
 };

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -9,7 +9,6 @@ const RightColumn: React.FC<RightColumnProps> = ({
 }) => {
 	return (
 		<div className="bg-red-500 flex flex-col items-start w-full">
-			{/* Toggle Button for Right Column */}
 			<button
 				onClick={toggleRightColumn}
 				className="bg-gray-700 text-white p-2 rounded w-8"
@@ -17,11 +16,9 @@ const RightColumn: React.FC<RightColumnProps> = ({
 				{isRightColumnVisible ? "→" : "←"}
 			</button>
 
-			{/* Show Right Column content only when expanded */}
 			{isRightColumnVisible && (
 				<>
 					<p>Right Column</p>
-					{/* <p>Areallylongword</p> */}
 				</>
 			)}
 		</div>

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -8,7 +8,7 @@ const RightColumn: React.FC<RightColumnProps> = ({
 	isRightColumnVisible,
 }) => {
 	return (
-		<div className="bg-red-500 h-full flex flex-col items-start">
+		<div className="bg-red-500 flex flex-col items-start">
 			{/* Toggle Button for Right Column */}
 			<button
 				onClick={toggleRightColumn}
@@ -18,7 +18,12 @@ const RightColumn: React.FC<RightColumnProps> = ({
 			</button>
 
 			{/* Show Right Column content only when expanded */}
-			{isRightColumnVisible && <p>Right Column</p>}
+			{isRightColumnVisible && (
+				<>
+					<p>Right Column</p>
+					{/* <p>Areallylongword</p> */}
+				</>
+			)}
 		</div>
 	);
 };

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -8,17 +8,17 @@ const RightColumn: React.FC<RightColumnProps> = ({
 	isRightColumnVisible,
 }) => {
 	return (
-		<div className="bg-red-500 p-4 h-full flex items-start">
+		<div className="bg-red-500 h-full flex flex-col items-start">
 			{/* Toggle Button for Right Column */}
 			<button
 				onClick={toggleRightColumn}
-				className="bg-gray-700 text-white p-2 rounded"
+				className="bg-gray-700 text-white p-2 rounded w-8"
 			>
 				{isRightColumnVisible ? "→" : "←"}
 			</button>
 
 			{/* Show Right Column content only when expanded */}
-			{isRightColumnVisible && <p className="ml-2">Right Column</p>}
+			{isRightColumnVisible && <p>Right Column</p>}
 		</div>
 	);
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,18 +1,21 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  content: [
-    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
-  ],
-  theme: {
-    extend: {
-      colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
-      },
-    },
-  },
-  plugins: [],
+	content: [
+		"./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+		"./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+		"./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+	],
+	theme: {
+		extend: {
+			colors: {
+				primaryWhite: "#ffffff",
+				primaryBlack: "#1d1b19",
+				grey: "#393834",
+				redFill: "#952f2d",
+				redBorder: "#b05447",
+			},
+		},
+	},
+	plugins: [],
 } satisfies Config;


### PR DESCRIPTION
I added containers for the Right, Middle, and Left Columns.

The middle column is broken up into a MiddleTopColumn and a MiddleBottomColumn components.

The RightColumn has a button that can close and open the right column, where the middle column take up the available space. 
<img width="949" alt="Closed Right Col" src="https://github.com/user-attachments/assets/c54701ae-0294-4113-a5c5-500b70710878" />
<img width="947" alt="Open Right Col" src="https://github.com/user-attachments/assets/53b7a1f8-77bc-46b8-920f-2e75e1787c6f" />

The LeftColumn stays at the same width.

I created MainNavigation and Footer placeholders.

I defined colors to be used in the tailwind.config.ts file. 
```
			colors: {
				primaryWhite: "#ffffff",
				primaryBlack: "#1d1b19",
				grey: "#393834",
				redFill: "#952f2d",
				redBorder: "#b05447",
			},
```