### PR TITLE
Dark mode tables

### DIFF
--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -10,7 +10,7 @@ export default function AicureToolFull() {
   const toggleRightColumn = () => setShowRight((prev) => !prev);
 
   return (
-    <div className="flex h-screen grid-cols-3">
+    <div className="flex h-screen grid-cols-3 bg-primaryBlack">
       <div className="min-w-[300px] max-w-[300px]">
         <LeftColumn />
       </div>

--- a/src/components/CollectionManager.tsx
+++ b/src/components/CollectionManager.tsx
@@ -7,8 +7,8 @@ export default function CollectionMangaer() {
         <h2 className="text-2xl font-bold text-primaryWhite">Collections</h2>
         <SaveButton />
       </div>
-      <div className="min-h-[200px] border-primaryWhite border rounded">
-        <p> place holder collections container</p>
+      <div className="min-h-[200px] border-grey border rounded">
+        <p className="p-2"> place holder collections container</p>
       </div>
     </div>
   );

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -192,7 +192,9 @@ export default function FileUploader({
                     className="flex items-center justify-between bg-selectedBlack text-primaryWhite p-3 rounded-md shadow-sm border-grey border"
                   >
                     <div className="flex items-center space-x-2">
-                      <span className="text-primaryWhite">{file.name}</span>
+                      <span className="text-primaryWhite max-w-[180px] overflow-x-auto whitespace-nowrap">
+                        {file.name}
+                      </span>
                       <span className="text-sm text-primaryWhite">
                         ({(file.size / 1024 / 1024).toFixed(2)} MB)
                       </span>

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -82,7 +82,6 @@ export default function FileUploader({
     setIsUploading(true);
     setUploadStatus("Uploading files...");
 
-
     // Upload all files to the endpoint
     for (const file of files) {
       try {
@@ -96,7 +95,7 @@ export default function FileUploader({
           formData,
           {
             headers: {
-            "Content-Type": "multipart/form-data",
+              "Content-Type": "multipart/form-data",
             },
             timeout: 30000,
             withCredentials: true,
@@ -105,12 +104,11 @@ export default function FileUploader({
         // print out the response data decoded
         // console.log(`Response: ${JSON.stringify(response.data, null, 2)}`);
         // console.log(`Session ID: ${response.data.session_id}`);
-        
-      
+
         // setSessionId(response.data.session_id);
         // onSessionUpdate?.(response.data.session_id);
         // console.log(`Session ID: ${response.data.session_id}`);
-        
+
         if (fileType == "excel" || fileType == "xlsx") {
           if (response.data.tables.length > 0) {
             setTables(response.data.tables);
@@ -123,7 +121,7 @@ export default function FileUploader({
         console.error(`Error uploading file ${file.name}:`, error);
       }
     }
-    
+
     const uploadedFiles = files.map((file) => ({
       name: file.name,
       type: getFileType(file.name),
@@ -139,7 +137,7 @@ export default function FileUploader({
     setUploadStatus("Files uploaded successfully!");
     setIsUploading(false);
   };
-    
+
   const removeFile = (fileName: string) => {
     setFiles(files.filter((file) => file.name !== fileName));
     setUploadedFiles((prev) => prev.filter((file) => file.name !== fileName));
@@ -147,10 +145,10 @@ export default function FileUploader({
   };
 
   return (
-    <section className="p-4 bg-gray-200 rounded-lg">
+    <section className="p-4 bg-selectedBlack rounded-lg">
       <div
         className={`relative p-8 ${
-          dragActive ? "bg-gray-300" : "bg-gray-100"
+          dragActive ? "bg-gray-300" : "bg-unSelectedBlack"
         } border-2 border-dashed border-gray-400 rounded-lg text-center transition-colors`}
         onDragEnter={handleDrag}
         onDragLeave={handleDrag}
@@ -167,7 +165,7 @@ export default function FileUploader({
         />
 
         <div className="space-y-4">
-          <div className="text-gray-700 font-medium">
+          <div className="text-primaryWhite font-medium">
             <p>Drag and drop your files here, or</p>
             <button
               onClick={() => inputRef.current?.click()}
@@ -184,18 +182,18 @@ export default function FileUploader({
 
           {files.length > 0 && (
             <div className="mt-6">
-              <h3 className="text-lg font-semibold text-gray-800 mb-2">
+              <h3 className="text-lg font-semibold text-primaryWhite mb-2">
                 Selected Files:
               </h3>
               <div className="space-y-2">
                 {files.map((file, idx) => (
                   <div
                     key={idx}
-                    className="flex items-center justify-between bg-white p-3 rounded-md shadow-sm"
+                    className="flex items-center justify-between bg-selectedBlack text-primaryWhite p-3 rounded-md shadow-sm border-grey border"
                   >
                     <div className="flex items-center space-x-2">
-                      <span className="text-gray-700">{file.name}</span>
-                      <span className="text-sm text-gray-500">
+                      <span className="text-primaryWhite">{file.name}</span>
+                      <span className="text-sm text-primaryWhite">
                         ({(file.size / 1024 / 1024).toFixed(2)} MB)
                       </span>
                     </div>

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -77,13 +77,24 @@ export default function RightColumn({
 
   return (
     <div className="bg-primaryBlack border-l-2 border-gray-700 pt-2 flex flex-col items-start w-full">
-      <button onClick={toggleRightColumn} className="text-white rounded">
-        {isRightColumnVisible ? (
-          <ChevronDoubleRightIcon className="h-8 w-8" />
-        ) : (
-          <ChevronDoubleLeftIcon className="h-8 w-8" />
-        )}
-      </button>
+      <div className="relative group">
+        <button onClick={toggleRightColumn} className="text-white rounded">
+          {isRightColumnVisible ? (
+            <ChevronDoubleRightIcon className="h-8 w-8" />
+          ) : (
+            <ChevronDoubleLeftIcon className="h-8 w-8" />
+          )}
+        </button>
+        {/* Tooltip */}
+        <span
+          className={`absolute top-full mt-1 whitespace-nowrap rounded bg-primaryBlack border-primaryWhite border text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 px-2 py-1 
+      ${
+        isRightColumnVisible ? "left-1/2 -translate-x-1/2" : "left-0 ml-[-30px]"
+      }`}
+        >
+          {isRightColumnVisible ? "Collapse" : "Expand"}
+        </span>
+      </div>
 
       {isRightColumnVisible && (
         <div className="p-2 w-full">

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -37,7 +37,7 @@ export default function RightColumn({
 
     if (type === "pdf") {
       return (
-        <div className="h-full w-full bg-white rounded-lg overflow-hidden flex flex-col">
+        <div className="h-full w-full bg-panelBlack rounded-lg overflow-hidden flex flex-col">
           <h3 className="p-3 bg-gray-100 text-gray-800 font-medium border-b">
             {name}
           </h3>
@@ -46,8 +46,8 @@ export default function RightColumn({
       );
     } else if (type === "png" || type === "jpg" || type === "jpeg") {
       return (
-        <div className="h-full w-full bg-white rounded-lg overflow-hidden flex flex-col">
-          <h3 className="p-2 bg-gray-100 text-gray-800 font-medium border-b">
+        <div className="h-full w-full bg-panelBlack rounded-lg overflow-hidden flex flex-col">
+          <h3 className="p-2 bg-gray-100 text-primaryWhite font-medium border-b">
             {name}
           </h3>
           <div className="p-2 flex items-center justify-center bg-gray-50 flex-1">
@@ -62,12 +62,12 @@ export default function RightColumn({
     }
 
     return (
-      <div className="h-full w-full bg-white rounded-lg overflow-hidden flex flex-col">
-        <h3 className="bg-gray-100 text-gray-800 font-medium border-b">
+      <div className="h-full w-full bg-selectedBlack border-grey border rounded-lg overflow-hidden flex flex-col mb-2">
+        <h3 className="bg-selectedBlack text-primaryWhite font-medium border-b pl-2">
           {name}
         </h3>
-        <div className="p-2 flex items-center justify-center bg-gray-50 flex-1">
-          <p className="text-gray-500">
+        <div className="p-2 flex items-center justify-center bg-selectedBlack flex-1">
+          <p className="text-primaryWhite">
             Preview not available for this file type
           </p>
         </div>

--- a/src/components/SummaryViewer.tsx
+++ b/src/components/SummaryViewer.tsx
@@ -123,7 +123,7 @@ export default function SummaryViewer({
 
   if (!csvFilename && !isImage && !isPDF) {
     return (
-      <div className="p-2 bg-gray-800 rounded-lg text-white">
+      <div className="p-2 bg-unSelectedBlack border-grey border rounded-lg text-white">
         <h2 className="text-xl font-bold mb-4">Analysis</h2>
         <p className="text-gray-400">Select a file to view its analysis</p>
       </div>
@@ -132,7 +132,7 @@ export default function SummaryViewer({
 
   if (isLoading) {
     return (
-      <div className="p-2 bg-gray-800 rounded-lg text-white">
+      <div className="p-2 bg-unSelectedBlack border-grey border rounded-lg text-white">
         <h2 className="text-xl font-bold mb-4">Analysis</h2>
         <p className="text-gray-400">
           Analyzing {isImage ? "image" : isPDF ? "pdf" : "table"} data...
@@ -143,7 +143,7 @@ export default function SummaryViewer({
 
   if (isError) {
     return (
-      <div className="p-2 bg-gray-800 rounded-lg text-white">
+      <div className="p-2 bg-unSelectedBlack border-grey border rounded-lg text-white">
         <h2 className="text-xl font-bold mb-4">Analysis</h2>
         <p className="text-red-500">
           Error analyzing {isImage ? "image" : isPDF ? "pdf" : "table"}:{" "}
@@ -155,7 +155,7 @@ export default function SummaryViewer({
 
   if (data?.error) {
     return (
-      <div className="p-2 bg-gray-800 rounded-lg text-white">
+      <div className="p-2 bg-unSelectedBlack border-grey border rounded-lg text-white">
         <h2 className="text-xl font-bold mb-4">Analysis</h2>
         <p className="text-red-500">Error: {data.error}</p>
       </div>
@@ -163,7 +163,7 @@ export default function SummaryViewer({
   }
 
   return (
-    <div className="p-2 bg-gray-800 rounded-lg text-white w-[400px] overflow-x-auto">
+    <div className="p-2 bg-unSelectedBlack border-grey border rounded-lg text-white w-[400px] overflow-x-auto">
       <h2 className="text-xl font-bold mb-4">Analysis</h2>
 
       {/* Summary Section */}

--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState } from "react";
-import { useSessionFileStore } from "@/store/useSessionFileStore"; // Import the store
+import { useSessionFileStore } from "@/store/useSessionFileStore";
 
 interface Table {
   csv_filename: string;
@@ -14,7 +14,6 @@ interface TableListProps {
 
 export default function TableList({ tables, onTableSelect }: TableListProps) {
   const [selectedTables, setSelectedTables] = useState<Table[]>([]);
-  // const sessionId = useSessionFileStore((state) => state.sessionId);
   const handlePreview = useSessionFileStore((state) => state.handlePreview);
 
   const handleTableSelect = (table: Table) => {
@@ -45,8 +44,6 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
       <h3 className="text-lg font-semibold text-primaryWhite bg-panelBlack mb-2">
         Available Tables
       </h3>
-
-      {/* Scrollable container */}
       <div className="max-h-[400px] overflow-y-auto bg-unSelectedBlack rounded">
         <div>
           {tables.map((table, idx) => (
@@ -113,7 +110,6 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
         </div>
       </div>
 
-      {/* Selection summary */}
       {selectedTables.length > 0 && (
         <div className=" mt-2 p-2 bg-blue-50 rounded bg-selectedBlack border-primaryWhite border">
           <p className="text-sm bg-selectedBlack">

--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -73,8 +73,9 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
                   )}
                   onClick={(e) => e.stopPropagation()}
                   onChange={() => handleTableSelect(table)}
-                  className="h-4 w-4 text-primaryWhite bg-unSelectedBlack rounded border-gray-300 focus:ring-blue-500"
+                  className="h-4 w-4 appearance-none checked:appearance-auto text-blue-600 bg-unSelectedBlack rounded border-brightGrey border focus:ring-blue-500"
                 />
+
                 <label htmlFor={`table-checkbox-${idx}`} className="sr-only">
                   Select {table.display_name}
                 </label>

--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -34,7 +34,8 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
   if (!tables.length) {
     return (
       <div className="p-2 bg-panelBlack rounded text-primaryWhite text-center">
-        No tables available. Please upload a file first.
+        <p>No tables available.</p>
+        <p>Please upload a file first.</p>
       </div>
     );
   }

--- a/src/components/TableList.tsx
+++ b/src/components/TableList.tsx
@@ -33,38 +33,38 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
 
   if (!tables.length) {
     return (
-      <div className="p-2 bg-gray-100 rounded text-gray-500 text-center">
+      <div className="p-2 bg-panelBlack rounded text-primaryWhite text-center">
         No tables available. Please upload a file first.
       </div>
     );
   }
 
   return (
-    <div className="bg-gray-200 rounded p-2">
-      <h3 className="text-lg font-semibold text-gray-800 mb-2">
+    <div className="bg-panelBlack border-grey border rounded p-2">
+      <h3 className="text-lg font-semibold text-primaryWhite bg-panelBlack mb-2">
         Available Tables
       </h3>
 
       {/* Scrollable container */}
-      <div className="max-h-[400px] overflow-y-auto bg-primaryWhite rounded">
+      <div className="max-h-[400px] overflow-y-auto bg-unSelectedBlack rounded">
         <div>
           {tables.map((table, idx) => (
             <div
               key={table.csv_filename}
               className={`
                 flex items-stretch justify-between w-full
-                p-2 cursor-pointer
+                p-2 cursor-pointer 
                 ${
                   selectedTables.some(
                     (t) => t.csv_filename === table.csv_filename
                   )
-                    ? "bg-blue-100"
-                    : "bg-primaryWhite hover:bg-gray-100 hover:rounded-none border border-transparent transition-colors"
+                    ? "bg-selectedBlack text-primaryWhite"
+                    : "bg-unSelectedBlack hover:bg-selectedBlack hover:rounded-none border border-transparent transition-colors"
                 }
               `}
               onClick={() => handleTableSelect(table)}
             >
-              <div className="flex items-center space-x-3">
+              <div className="flex items-center space-x-3 bg-unSelectedBlack">
                 <input
                   type="checkbox"
                   checked={selectedTables.some(
@@ -72,29 +72,31 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
                   )}
                   onClick={(e) => e.stopPropagation()}
                   onChange={() => handleTableSelect(table)}
-                  className="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                  className="h-4 w-4 text-primaryWhite bg-unSelectedBlack rounded border-gray-300 focus:ring-blue-500"
                 />
                 <label htmlFor={`table-checkbox-${idx}`} className="sr-only">
                   Select {table.display_name}
                 </label>
                 <div>
-                  <p className="text-gray-700 text-sm">{table.csv_filename}</p>
-                  <p className="text-xs text-gray-500">{table.display_name}</p>
+                  <p className="text-primaryWhite text-sm">
+                    {table.csv_filename}
+                  </p>
+                  <p className="text-xs text-primaryWhite">
+                    {table.display_name}
+                  </p>
                 </div>
               </div>
 
               {/* Preview/Actions buttons */}
               <div className="flex flex-col items-center text-right">
                 <button
-                  className="px-3 py-1 text-sm text-primaryBlue hover:bg-redFill hover:text-primaryWhite rounded duration-300 transition-colors"
-                  onClick={() =>
-                    handlePreview(table.csv_filename)
-                  }
+                  className="px-3 py-1 text-sm text-primaryWhite hover:bg-redFill hover:text-primaryWhite rounded duration-300 transition-colors"
+                  onClick={() => handlePreview(table.csv_filename)}
                 >
                   Preview
                 </button>
                 <button
-                  className="px-3 py-1 text-sm text-primaryBlue hover:bg-redFill hover:text-primaryWhite rounded duration-300 transition-colors"
+                  className="px-3 py-1 text-sm text-primaryWhite hover:bg-redFill hover:text-primaryWhite rounded duration-300 transition-colors"
                   onClick={(e) => {
                     e.stopPropagation();
                     // Add download functionality
@@ -111,8 +113,8 @@ export default function TableList({ tables, onTableSelect }: TableListProps) {
 
       {/* Selection summary */}
       {selectedTables.length > 0 && (
-        <div className=" mt-2 p-2 bg-blue-50 rounded border-primaryBlue border">
-          <p className="text-sm text-primaryBlue">
+        <div className=" mt-2 p-2 bg-blue-50 rounded bg-selectedBlack border-primaryWhite border">
+          <p className="text-sm bg-selectedBlack">
             {selectedTables.length} table
             {selectedTables.length !== 1 ? "s" : ""} selected
           </p>

--- a/src/components/TablePreviewer.tsx
+++ b/src/components/TablePreviewer.tsx
@@ -16,6 +16,14 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useSessionFileStore } from "../store/useSessionFileStore"; // Import the store
 import { PreviewResponse } from "@/types/files";
+import resolveConfig from "tailwindcss/resolveConfig";
+import tailwindConfig from "@config";
+
+const fullConfig = resolveConfig(tailwindConfig);
+const greyColor = fullConfig.theme.colors.grey;
+const primaryBlack = fullConfig.theme.colors.primaryBlack;
+const primaryWhite = fullConfig.theme.colors.primaryWhite;
+const unSelectedBlack = fullConfig.theme.colors.unSelectedBlack;
 
 const fetchTablePreview = async ({
   queryKey,
@@ -59,7 +67,14 @@ export default function TablePreviewer() {
   }
 
   return (
-    <Card sx={{ mt: 3 }}>
+    <Card
+      sx={{
+        mt: 3,
+        bgcolor: unSelectedBlack,
+        color: primaryWhite,
+        border: `1px solid ${greyColor}`,
+      }}
+    >
       <CardContent>
         {isLoading ? (
           <CircularProgress />
@@ -70,12 +85,21 @@ export default function TablePreviewer() {
             <Typography variant="h6" gutterBottom>
               Table Preview: {previewCsv}
             </Typography>
-            <TableContainer component={Paper}>
+            <TableContainer
+              component={Paper}
+              sx={{
+                border: `1px solid ${greyColor}`,
+                bgcolor: primaryBlack,
+                color: primaryWhite,
+              }}
+            >
               <Table size="small">
                 <TableHead>
                   <TableRow>
                     {data.columns.map((col, index) => (
-                      <TableCell key={index}>{col}</TableCell>
+                      <TableCell key={index} sx={{ color: primaryWhite }}>
+                        {col}
+                      </TableCell>
                     ))}
                   </TableRow>
                 </TableHead>
@@ -83,7 +107,9 @@ export default function TablePreviewer() {
                   {data.preview.map((row, rowIndex) => (
                     <TableRow key={rowIndex}>
                       {data.columns.map((col, colIndex) => (
-                        <TableCell key={colIndex}>{row[col]}</TableCell>
+                        <TableCell key={colIndex} sx={{ color: primaryWhite }}>
+                          {row[col]}
+                        </TableCell>
                       ))}
                     </TableRow>
                   ))}

--- a/src/components/UploadedFiles.tsx
+++ b/src/components/UploadedFiles.tsx
@@ -106,7 +106,7 @@ export default function UploadedFiles({
                     checked={selectedFiles.some((f) => f.name === file.name)}
                     onChange={() => handleFileSelect(file)}
                     onClick={(e) => e.stopPropagation()}
-                    className="h-4 w-4 text-blue-600 bg-unSelectedBlack rounded border-gray-300 focus:ring-blue-500"
+                    className="h-4 w-4 appearance-none text-blue-600 bg-unSelectedBlack rounded border-brightGrey border focus:ring-blue-500"
                   />
                 </td>
                 <td className="p-2 flex items-center gap-2">

--- a/src/components/UploadedFiles.tsx
+++ b/src/components/UploadedFiles.tsx
@@ -91,7 +91,7 @@ export default function UploadedFiles({
                 className={`cursor-pointer hover:bg-selectedBlack
                   ${
                     selectedFiles.some((f) => f.name === file.name)
-                      ? "bg-blue-100"
+                      ? "bg-selectedBlack"
                       : ""
                   }
                   ${
@@ -146,8 +146,8 @@ export default function UploadedFiles({
       </div>
 
       {selectedFiles.length > 0 && (
-        <div className="mt-2 p-2 bg-blue-50 rounded border-primaryBlue border">
-          <p className="text-sm text-primaryBlue">
+        <div className="mt-2 p-2 rounded border-grey border bg-unSelectedBlack">
+          <p className="text-sm text-primaryWhite bg-unSelectedBlack">
             {selectedFiles.length} file{selectedFiles.length !== 1 ? "s" : ""}{" "}
             selected
           </p>

--- a/src/components/UploadedFiles.tsx
+++ b/src/components/UploadedFiles.tsx
@@ -60,7 +60,7 @@ export default function UploadedFiles({
 
   if (!files.length) {
     return (
-      <div className="p-2 bg-gray-100 rounded text-gray-500 text-center">
+      <div className="p-2 bg-unSelectedBlack rounded text-primaryWhite text-center">
         No files uploaded yet.
       </div>
     );
@@ -72,9 +72,9 @@ export default function UploadedFiles({
         Uploaded Files
       </h3>
 
-      <div className="max-h-[300px] overflow-y-auto bg-primaryWhite rounded">
+      <div className="max-h-[300px] overflow-y-auto bg-unselectedBlack rounded">
         <table className="w-full">
-          <thead className="bg-gray-100 text-gray-700 text-sm">
+          <thead className="bg-unselectedBlack text-primaryWhite text-sm">
             <tr>
               <th className="p-2 text-left w-12"></th>
               <th className="p-2 text-left">Name</th>
@@ -88,7 +88,7 @@ export default function UploadedFiles({
             {files.map((file) => (
               <tr
                 key={file.name}
-                className={`cursor-pointer hover:bg-gray-100
+                className={`cursor-pointer hover:bg-selectedBlack
                   ${
                     selectedFiles.some((f) => f.name === file.name)
                       ? "bg-blue-100"
@@ -106,21 +106,21 @@ export default function UploadedFiles({
                     checked={selectedFiles.some((f) => f.name === file.name)}
                     onChange={() => handleFileSelect(file)}
                     onClick={(e) => e.stopPropagation()}
-                    className="h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                    className="h-4 w-4 text-blue-600 bg-unSelectedBlack rounded border-gray-300 focus:ring-blue-500"
                   />
                 </td>
                 <td className="p-2 flex items-center gap-2">
                   {getFileIcon(file.type)}
-                  <span className="text-gray-700 text-sm">{file.name}</span>
+                  <span className="text-primaryWhite text-sm">{file.name}</span>
                 </td>
                 <td className="p-2">
                   <div className="flex items-center">
                     <div className="h-3 w-3 rounded-full bg-green-400 mr-2"></div>
-                    <span className="text-sm text-gray-600">Ready</span>
+                    <span className="text-sm text-primiaryWhite">Ready</span>
                   </div>
                 </td>
-                <td className="p-2 text-sm text-gray-600">{file.type}</td>
-                <td className="p-2 text-sm text-gray-600">
+                <td className="p-2 text-sm text-primiaryWhite">{file.type}</td>
+                <td className="p-2 text-sm text-primiaryWhite">
                   {file.dateCreated}
                 </td>
                 <td className="p-2">

--- a/src/components/UploadedFiles.tsx
+++ b/src/components/UploadedFiles.tsx
@@ -106,7 +106,7 @@ export default function UploadedFiles({
                     checked={selectedFiles.some((f) => f.name === file.name)}
                     onChange={() => handleFileSelect(file)}
                     onClick={(e) => e.stopPropagation()}
-                    className="h-4 w-4 appearance-none text-blue-600 bg-unSelectedBlack rounded border-brightGrey border focus:ring-blue-500"
+                    className="h-4 w-4 appearance-none checked:appearance-auto text-blue-600 bg-unSelectedBlack rounded border-brightGrey border focus:ring-blue-500"
                   />
                 </td>
                 <td className="p-2 flex items-center gap-2">

--- a/src/components/UploadedFiles.tsx
+++ b/src/components/UploadedFiles.tsx
@@ -29,7 +29,7 @@ export default function UploadedFiles({
       const blob = await response.blob();
       const fileType = blob.type;
       // convert mime type to file type
-      const newFileType = fileType.split('/').pop() || "";
+      const newFileType = fileType.split("/").pop() || "";
       console.log(newFileType);
       const fileObj = new File([blob], file.name, { type: fileType });
 
@@ -38,7 +38,6 @@ export default function UploadedFiles({
         type: newFileType,
         file: fileObj,
       });
-
     } catch (error) {
       console.error("Error previewing file:", error);
     }
@@ -54,7 +53,9 @@ export default function UploadedFiles({
   };
 
   const canPreview = (fileType: string) => {
-    return ["pdf", "png", "jpg", "jpeg", "xlsx", "xls", "csv"].includes(fileType.toLowerCase());
+    return ["pdf", "png", "jpg", "jpeg", "xlsx", "xls", "csv"].includes(
+      fileType.toLowerCase()
+    );
   };
 
   if (!files.length) {
@@ -66,8 +67,8 @@ export default function UploadedFiles({
   }
 
   return (
-    <div className="bg-gray-200 rounded p-2">
-      <h3 className="text-lg font-semibold text-gray-800 mb-2">
+    <div className="bg-panelBlack border-grey border rounded p-2">
+      <h3 className="text-lg font-semibold text-primaryWhite mb-2">
         Uploaded Files
       </h3>
 

--- a/src/components/base/FolderPlusButton.tsx
+++ b/src/components/base/FolderPlusButton.tsx
@@ -12,13 +12,9 @@ export default function FolderPlusButton({ onClick }: FolderPlusButtonProps) {
 
   return (
     <div className="relative group">
-      {/* Button */}
       <button onClick={handleClick} className="flex">
         <FolderPlusIcon className="h-8 w-8 stroke-primaryWhite stroke-1 text-primaryBlack p-1 hover:stroke-redFill transition-colors duration-300" />
-
       </button>
-
-      {/* Tooltip (appears on hover) - Hover to display Add Folder is not working */}
       <span className="absolute top-full mt-1 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-primaryBlack border-primaryWhite border text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 px-2 py-1">
         Add folder
       </span>

--- a/src/components/base/UploadFileButton.tsx
+++ b/src/components/base/UploadFileButton.tsx
@@ -57,7 +57,7 @@ export default function UploadFileButton({
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-black bg-opacity-25" />
+            <div className="fixed inset-0 bg-black bg-opacity-70" />
           </TransitionChild>
 
           <div className="fixed inset-0 overflow-y-auto">
@@ -71,15 +71,14 @@ export default function UploadFileButton({
                 leaveFrom="opacity-100 scale-100"
                 leaveTo="opacity-0 scale-95"
               >
-                <DialogPanel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+                <DialogPanel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-grey border border-primaryWhite p-6 text-left align-middle shadow-xl transition-all">
                   <FileUploader
                     onTablesUpdate={handleTablesUpdate}
-                    // onSessionUpdate={handleSessionUpdate}
                     onFilesUpdate={handleFilesUpdate}
                   />
                   <button
                     onClick={() => setIsOpen(false)}
-                    className="mt-4 px-4 py-2 bg-red-600 text-white rounded"
+                    className="flex justify-center items-center border border-primaryWhite mt-4 px-4 py-2 hover:bg-red-600 bg-redFill hover:redBorder transition-colors duration-300 text-white rounded"
                   >
                     Close
                   </button>

--- a/src/components/chatbot/ChatbotComponent.tsx
+++ b/src/components/chatbot/ChatbotComponent.tsx
@@ -104,14 +104,14 @@ export default function ChatbotComponent() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex items-center justify-center h-full bg-primaryBlack">
         Loading chatbot...
       </div>
     );
   }
   // max-w-full overflow-hidden, on their own didn't help
   return (
-    <div className=" flex flex-col flex-grow-0">
+    <div className="flex flex-col flex-grow-0">
       <Chatbot
         config={config}
         messageParser={MessageParser}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,7 @@ export default {
         redBorder: "#b05447",
         panelBlack: "#121212",
         selectedBlack: "#212121",
-        unselectedBlack: "#000000",
+        unSelectedBlack: "#000000",
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,7 @@ export default {
         primaryBlack: "#1d1b19",
         primaryBlue: "#0b3d91",
         grey: "#393834",
+        brightGrey: "#ececec",
         redFill: "#952f2d",
         redBorder: "#b05447",
         panelBlack: "#121212",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@config": ["./tailwind.config.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
Changed all tables to display in dark mode to match the Figma.

Fix area under "Loading Chatbot" to match the background.

Added descriptions under the collapse and expand buttons for right column. Shift expand to the left to be visible when right column is collapsed.


<img width="991" alt="Dark Mode Tables" src="https://github.com/user-attachments/assets/0dc259af-4866-4bda-8d11-5ec33fea48d9" />
