### PR TITLE
Refactored isRightColumnVisible to be tracked by Zustand

### DIFF
--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -4,10 +4,14 @@ import LeftColumn from "./LeftColumn";
 import RightColumn from "./RightColumn";
 import MiddleTopColumn from "./MiddleTopColumn";
 import MiddleBottomColumn from "./MiddleBottomColumn";
+import { useIsRightVisible } from "@/store/useIsRightVisible";
 
 export default function AicureToolFull() {
-  const [showRight, setShowRight] = useState(true);
-  const toggleRightColumn = () => setShowRight((prev) => !prev);
+  // const [showRight, setShowRight] = useState(true);
+  // const toggleRightColumn = () => setShowRight((prev) => !prev);
+  const isRightColumnVisible = useIsRightVisible(
+    (state) => state.isRightColumnVisible
+  );
 
   return (
     <div className="flex h-screen grid-cols-3 bg-primaryBlack">
@@ -25,12 +29,11 @@ export default function AicureToolFull() {
       </div>
 
       <div
-        className={`${showRight ? "min-w-[300px]" : "w-[36px]"} flex h-full`}
+        className={`${
+          isRightColumnVisible ? "min-w-[300px]" : "w-[36px]"
+        } flex h-full`}
       >
-        <RightColumn
-          toggleRightColumn={toggleRightColumn}
-          isRightColumnVisible={showRight}
-        />
+        <RightColumn />
       </div>
     </div>
   );

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -5,17 +5,22 @@ import {
 import TablePreviewer from "./TablePreviewer";
 import { useState, useEffect } from "react";
 import { useSessionFileStore } from "@/store/useSessionFileStore";
-import { RightColumnProps } from "@/types/files";
+// import { RightColumnProps } from "@/types/files";
 import SummaryViewer from "./SummaryViewer";
+import { useIsRightVisible } from "@/store/useIsRightVisible";
 
-export default function RightColumn({
-  toggleRightColumn,
-  isRightColumnVisible,
-}: RightColumnProps) {
+export default function RightColumn() {
   const previewFile = useSessionFileStore((state) => state.previewFile);
   const sessionId = useSessionFileStore((state) => state.sessionId);
   const previewCsv = useSessionFileStore((state) => state.previewCsv);
   const [objectUrl, setObjectUrl] = useState<string>("");
+
+  const isRightColumnVisible = useIsRightVisible(
+    (state) => state.isRightColumnVisible
+  );
+  const toggleRightColumn = useIsRightVisible(
+    (state) => state.toggleRightColumn
+  );
 
   // Create object URL when previewFile changes
   useEffect(() => {
@@ -101,7 +106,6 @@ export default function RightColumn({
           <TablePreviewer />
           {renderFilePreview()}
           <SummaryViewer
-            // sessionId={sessionId || ""}
             csvFilename={previewCsv || ""}
             file={previewFile?.file}
             fileName={previewFile?.name || ""}

--- a/src/components/TablePreviewer.tsx
+++ b/src/components/TablePreviewer.tsx
@@ -45,6 +45,7 @@ const fetchTablePreview = async ({
       credentials: "include",
     }
   );
+
   if (!response.ok) {
     throw new Error("Network response was not ok");
   }
@@ -61,7 +62,7 @@ export default function TablePreviewer() {
     queryFn: fetchTablePreview,
     enabled: !!previewCsv, // Only fetch if previewCsv is available
   });
-
+  console.log("Preview button clicked????? in TablePreviewer func");
   if (!previewCsv) {
     return null;
   }

--- a/src/store/useIsRightVisible.ts
+++ b/src/store/useIsRightVisible.ts
@@ -1,0 +1,14 @@
+import { create } from "zustand";
+
+interface IsRightVisible {
+  isRightColumnVisible: boolean;
+  toggleRightColumn: () => void;
+  setRightColumnVisible: (visible: boolean) => void;
+}
+
+export const useIsRightVisible = create<IsRightVisible>((set) => ({
+  isRightColumnVisible: true,
+  toggleRightColumn: () =>
+    set((state) => ({ isRightColumnVisible: !state.isRightColumnVisible })),
+  setRightColumnVisible: (visible) => set({ isRightColumnVisible: visible }),
+}));


### PR DESCRIPTION
Refactored `isRightColumnVisible` to be tracked by Zustand, instead of useState and passing the boolean with props.