### PR TITLE
Fixed styling for tabs in Scientific Data Curation section

### DIFF
--- a/src/components/middleTopCol/PDFExtractorComponent.tsx
+++ b/src/components/middleTopCol/PDFExtractorComponent.tsx
@@ -29,7 +29,7 @@ export default function PDFExtractor() {
 
   return (
     <div className="w-full overflow-auto">
-      <div className="min-w-[400px] max-w-[850px] rounded overflow-hidden border border-grey">
+      <div className="rounded overflow-hidden border border-grey">
         <CollapsibleSection
           title="Title"
           fetchFunction={createFetchFunction("Title")}

--- a/src/components/middleTopCol/StudyComponent.tsx
+++ b/src/components/middleTopCol/StudyComponent.tsx
@@ -10,7 +10,7 @@ export default function StudyComponent() {
 
   return (
     <div className="w-full overflow-auto">
-      <div className="min-w-[400px] max-w-[850px] rounded overflow-hidden border border-grey">
+      <div className="rounded overflow-hidden border border-grey">
         <CollapsibleSection
           title="Description"
           fetchFunction={createFetchFunction("Description")}


### PR DESCRIPTION
Fixed the width of the Study and PDF Extractor areas to take up the full width of their containers. Whether very wide or skinny it takes up all the available space.

<img width="1509" alt="wide view" src="https://github.com/user-attachments/assets/7bd02a0d-2c5e-442a-80d3-d4c067f8a460" />
<img width="741" alt="skinny view" src="https://github.com/user-attachments/assets/41ad664e-68a1-42bc-b76f-b8492dc14039" />
