### PR TITLE
Create a cache of the returned object from rag call

### DIFF
--- a/fastapi-backend/config/rag_templates.py
+++ b/fastapi-backend/config/rag_templates.py
@@ -7,7 +7,8 @@ TEMPLATES: Dict[str, Dict[str, str]] = {
      "decription":  "A 2-sentence overview of the main findings",
      "studies" : "Summarize the goals of the study",
      "keywords": "List 4-6 terms capturing the study's topics",
-     "subjects/biospecimens":  "Name any species used in the experiments",
+     "subjects/biospecimens":  "Name any species used in the experiments and how many species",
+     "hardware": "Name any hardware used and its identifier numbers",
      "methods":  "Brief description of the experimental methods"
   },
   "geology": {

--- a/fastapi-backend/config/rag_templates.py
+++ b/fastapi-backend/config/rag_templates.py
@@ -7,7 +7,7 @@ TEMPLATES: Dict[str, Dict[str, str]] = {
      "decription":  "A 2-sentence overview of the main findings",
      "studies" : "Summarize the goals of the study",
      "keywords": "List 4-6 terms capturing the study's topics",
-     "species":  "Name any species used in the experiments",
+     "subjects/biospecimens":  "Name any species used in the experiments",
      "methods":  "Brief description of the experimental methods"
   },
   "geology": {

--- a/src/components/base/AiGenerateButton.tsx
+++ b/src/components/base/AiGenerateButton.tsx
@@ -3,6 +3,7 @@ import { SparklesIcon } from "@heroicons/react/24/outline";
 
 interface AiGenerateButtonProps {
   onClick?: () => Promise<void> | void;
+  disabled: boolean;
 }
 
 export default function AiGenerateButton({ onClick }: AiGenerateButtonProps) {

--- a/src/components/base/CollapsibleSection.tsx
+++ b/src/components/base/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from "react";
+import { useState } from "react";
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -18,7 +18,6 @@ export default function CollapsibleSection({
   isLoading = false,
 }: CollapsibleSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
-  // const [data, fetchData] = useAiGenerateFetch(fetchFunction);
   const Icon = sectionIcons[title] || DocumentIcon; // Dynamically get the correct icon | backup icon if not in Dict
 
   // Toggles the section visibility

--- a/src/components/base/CollapsibleSection.tsx
+++ b/src/components/base/CollapsibleSection.tsx
@@ -1,8 +1,11 @@
 import { useState, ReactNode } from "react";
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ArrowPathIcon,
+} from "@heroicons/react/24/solid";
 import { CollapsibleSectionProps } from "@/types/files";
 import AiGenerateButton from "@/components/base/AiGenerateButton";
-import useAiGenerateFetch from "../../hooks/useAiGenerateFetch";
 import { sectionIcons } from "../../../util/sectionIcons";
 import { DocumentIcon } from "@heroicons/react/24/outline";
 import EditableTextArea from "./EditableTextArea";
@@ -12,6 +15,7 @@ export default function CollapsibleSection({
   onGenerate,
   value,
   onChange,
+  isLoading = false,
 }: CollapsibleSectionProps) {
   const [isOpen, setIsOpen] = useState(false);
   // const [data, fetchData] = useAiGenerateFetch(fetchFunction);
@@ -58,7 +62,15 @@ export default function CollapsibleSection({
       {/* Content */}
       {isOpen && (
         <div id={`section-content-${title}`} className="p-4">
-          <AiGenerateButton onClick={onGenerate} />
+          <div className="flex items-center gap-2">
+            <AiGenerateButton onClick={onGenerate} disabled={isLoading} />
+            {isLoading && (
+              <ArrowPathIcon
+                className="loader h-6 w-6 animate-spin"
+                aria-label="Loading…"
+              />
+            )}
+          </div>
           <EditableTextArea
             value={value}
             onChange={onChange}

--- a/src/components/middleTopCol/StudyComponent.tsx
+++ b/src/components/middleTopCol/StudyComponent.tsx
@@ -65,7 +65,7 @@ export default function StudyComponent() {
               onGenerate={() => onGenerate(section)}
               value={ragData[section]}
               onChange={(txt) => updateRagSection(section, txt)}
-              isLoading={loadingSection === section} // <-- pass this in
+              isLoading={loadingSection === section}
             />
           )
         )}

--- a/src/components/middleTopCol/StudyComponent.tsx
+++ b/src/components/middleTopCol/StudyComponent.tsx
@@ -13,6 +13,13 @@ export default function StudyComponent() {
   const fullRagData = useSessionFileStore((s) => s.fullRagData); // whole obj from rag call
   const updateRagSection = useSessionFileStore((s) => s.updateRagSection);
   const ragData = useSessionFileStore((s) => s.ragData); // single description, leave to be editable
+
+  const CollapsibleSectionTitles = [
+    "description",
+    "studies",
+    "subjects/biospecimens",
+    "hardware",
+  ];
   // grab the current file names from selectedFiles
   const selectedFileNames = useMemo(
     () => selectedFiles.map((f) => f.name),
@@ -57,18 +64,16 @@ export default function StudyComponent() {
   return (
     <div className="w-full overflow-auto">
       <div className="rounded overflow-hidden border border-grey">
-        {["description", "studies", "subjects/biospecimens", "hardware"].map(
-          (section) => (
-            <CollapsibleSection
-              key={section}
-              title={section}
-              onGenerate={() => onGenerate(section)}
-              value={ragData[section]}
-              onChange={(txt) => updateRagSection(section, txt)}
-              isLoading={loadingSection === section}
-            />
-          )
-        )}
+        {CollapsibleSectionTitles.map((section) => (
+          <CollapsibleSection
+            key={section}
+            title={section}
+            onGenerate={() => onGenerate(section)}
+            value={ragData[section]}
+            onChange={(txt) => updateRagSection(section, txt)}
+            isLoading={loadingSection === section}
+          />
+        ))}
       </div>
     </div>
   );

--- a/src/components/middleTopCol/StudyComponent.tsx
+++ b/src/components/middleTopCol/StudyComponent.tsx
@@ -55,17 +55,12 @@ export default function StudyComponent() {
           value={ragData.studies}
           onChange={(txt) => updateRagSection("studies", txt)}
         ></CollapsibleSection>
-        {/*
-        <CollapsibleSection
-          title="payloads"
-          fetchFunction={createFetchFunction("payloads")}
-        >
-          <></>
-        </CollapsibleSection>
-
+        {/* 
         <CollapsibleSection
           title="subjects/biospecimens"
-          fetchFunction={createFetchFunction("subjects/biospecimens")}
+          onGenerate={() => onGenerate("subjects/biospecimens")}
+          value={ragData.subjects/biospecimens}
+          onChange={(txt) => updateRagSection("subjects/biospecimens", txt)}}
         >
           <></>
         </CollapsibleSection>

--- a/src/components/middleTopCol/StudyComponent.tsx
+++ b/src/components/middleTopCol/StudyComponent.tsx
@@ -1,20 +1,16 @@
 "use client";
 import { useState, useMemo } from "react";
 import CollapsibleSection from "@/components/base/CollapsibleSection";
-import EditableTextArea from "../base/EditableTextArea";
 import { useSessionFileStore } from "@/store/useSessionFileStore";
 import { generateWithTemplate } from "@/lib/ragClient";
 
 export default function StudyComponent() {
-  // const [description, setDescription] = useState<string>(""); // seems like not being used but are
-  // const [studies, setStudies] = useState<string>(""); // will need to add in other CollapsibleSection titles
-  // const [species, setSpecies ] = useState<string>("");
+  const [loadingSection, setLoadingSection] = useState<string | null>(null);
 
   // 1) Select the raw UploadedFile[] from Zustand (stable until it really changes)
   const selectedFiles = useSessionFileStore((s) => s.selectedFiles);
   const setFullRagData = useSessionFileStore((state) => state.setFullRagData);
   const fullRagData = useSessionFileStore((s) => s.fullRagData); // whole obj from rag call
-  // const setRagData = useSessionFileStore((s) => s.setRagData);
   const updateRagSection = useSessionFileStore((s) => s.updateRagSection);
   const ragData = useSessionFileStore((s) => s.ragData); // single description, leave to be editable
   // grab the current file names from selectedFiles
@@ -28,60 +24,51 @@ export default function StudyComponent() {
     if (fullRagData[section]) {
       console.log("updating section, ", section, ", no rag call");
       updateRagSection(section, fullRagData[section] as string);
-    } else {
-      console.log("Preparing to FETCH, selectedFileNames", selectedFileNames);
+      return;
+    }
 
+    setLoadingSection(section);
+    try {
+      console.log("Preparing to FETCH, selectedFileNames", selectedFileNames);
       const fullSectionObj = await generateWithTemplate(
         selectedFileNames,
         "biophysics" // hard‐coded template for now
       );
 
       // normalize every value to a string
-      const normalized: Record<string, string> = Object.fromEntries(
+      const normalized = Object.fromEntries(
         Object.entries(fullSectionObj).map(([k, v]) => [
           k,
           typeof v === "string" ? v : JSON.stringify(v),
         ])
-      );
-      // store the fullRagData rag object separately
+      ) as Record<string, string>;
+      // store the normalized fullRagData rag object separately
       setFullRagData(normalized);
 
       console.log("After fetch, fullSectionObj obj", fullSectionObj);
-      // update one section at a time:
+      // update the section where the button was clicked:
+      // We can make it so that every section is updated instead of just one.
       updateRagSection(section, normalized[section]);
+    } finally {
+      setLoadingSection(null);
     }
   };
 
   return (
     <div className="w-full overflow-auto">
       <div className="rounded overflow-hidden border border-grey">
-        <CollapsibleSection
-          title="description"
-          onGenerate={() => onGenerate("description")}
-          value={ragData.description}
-          onChange={(txt) => updateRagSection("description", txt)}
-        ></CollapsibleSection>
-
-        <CollapsibleSection
-          title="studies"
-          onGenerate={() => onGenerate("studies")}
-          value={ragData.studies}
-          onChange={(txt) => updateRagSection("studies", txt)}
-        ></CollapsibleSection>
-
-        <CollapsibleSection
-          title="subjects/biospecimens"
-          onGenerate={() => onGenerate("subjects/biospecimens")}
-          value={ragData["subjects/biospecimens"]}
-          onChange={(txt) => updateRagSection("subjects/biospecimens", txt)}
-        ></CollapsibleSection>
-
-        <CollapsibleSection
-          title="hardware"
-          onGenerate={() => onGenerate("hardware")}
-          value={ragData.hardware}
-          onChange={(txt) => updateRagSection("hardware", txt)}
-        ></CollapsibleSection>
+        {["description", "studies", "subjects/biospecimens", "hardware"].map(
+          (section) => (
+            <CollapsibleSection
+              key={section}
+              title={section}
+              onGenerate={() => onGenerate(section)}
+              value={ragData[section]}
+              onChange={(txt) => updateRagSection(section, txt)}
+              isLoading={loadingSection === section} // <-- pass this in
+            />
+          )
+        )}
       </div>
     </div>
   );

--- a/src/components/middleTopCol/StudyComponent.tsx
+++ b/src/components/middleTopCol/StudyComponent.tsx
@@ -55,22 +55,21 @@ export default function StudyComponent() {
           value={ragData.studies}
           onChange={(txt) => updateRagSection("studies", txt)}
         ></CollapsibleSection>
-        {/* 
+
         <CollapsibleSection
           title="subjects/biospecimens"
           onGenerate={() => onGenerate("subjects/biospecimens")}
-          value={ragData.subjects/biospecimens}
-          onChange={(txt) => updateRagSection("subjects/biospecimens", txt)}}
-        >
-          <></>
-        </CollapsibleSection>
+          value={ragData["subjects/biospecimens"]}
+          onChange={(txt) => updateRagSection("subjects/biospecimens", txt)}
+        ></CollapsibleSection>
 
         <CollapsibleSection
           title="hardware"
-          fetchFunction={createFetchFunction("hardware")}
-        >
-          <></>
-        </CollapsibleSection>
+          onGenerate={() => onGenerate("hardware")}
+          value={ragData.hardware}
+          onChange={(txt) => updateRagSection("hardware", txt)}
+        ></CollapsibleSection>
+        {/* 
 
         <CollapsibleSection
           title="publications"

--- a/src/types/files.ts
+++ b/src/types/files.ts
@@ -101,6 +101,7 @@ export interface CollapsibleSectionProps {
   onGenerate: () => Promise<void>;
   value: string;
   onChange: (txt: string) => void;
+  isLoading?: boolean;
 }
 
 export interface EditableTextAreaProps {


### PR DESCRIPTION
Created a cache saved in Zustand's `useSessionFileStore` of the returned object with generated descriptions based on the template. As the object returns every field. When a second ai-generate-button is clicked in a separate section, it checks the cache and places in the description.

Created a spinning icon for when the rag fetch call is made, because it takes like 8 seconds.