### PR TITLE
Add responsive design for Left and Right Columns

### DIFF
--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -29,7 +29,7 @@ export default function AicureToolFull() {
       <div
         className={`${
           isRightColumnVisible
-            ? "min-w-[300px] max-w-[400px] 2xl:min-w-[400px] 2xl:max-w-[450px] "
+            ? "min-w-[300px] max-w-[400px] 2xl:min-w-[400px] 2xl:max-w-[450px]"
             : "w-[36px]"
         } flex h-full`}
       >

--- a/src/components/AicureToolFull.tsx
+++ b/src/components/AicureToolFull.tsx
@@ -13,7 +13,7 @@ export default function AicureToolFull() {
 
   return (
     <div className="flex h-screen grid-cols-3 bg-primaryBlack">
-      <div className="min-w-[300px] max-w-[300px]">
+      <div className="min-w-[300px] max-w-[300px] 2xl:min-w-[450px] 2xl:max-w-[450px]">
         <LeftColumn />
       </div>
       {/* flex-grow has to be here to allow right col to collapse */}
@@ -28,7 +28,9 @@ export default function AicureToolFull() {
 
       <div
         className={`${
-          isRightColumnVisible ? "min-w-[300px] max-w-[400px]" : "w-[36px]"
+          isRightColumnVisible
+            ? "min-w-[300px] max-w-[400px] 2xl:min-w-[400px] 2xl:max-w-[450px] "
+            : "w-[36px]"
         } flex h-full`}
       >
         <RightColumn />

--- a/src/components/RightColumn.tsx
+++ b/src/components/RightColumn.tsx
@@ -1,7 +1,4 @@
-import {
-  ChevronDoubleRightIcon,
-  ChevronDoubleLeftIcon,
-} from "@heroicons/react/24/outline";
+import { ChevronRightIcon, ChevronLeftIcon } from "@heroicons/react/24/outline";
 import TablePreviewer from "./TablePreviewer";
 import { useState, useEffect } from "react";
 import { useSessionFileStore } from "@/store/useSessionFileStore";
@@ -43,9 +40,9 @@ export default function RightColumn() {
           className="text-primaryWhite rounded"
         >
           {isRightColumnVisible ? (
-            <ChevronDoubleRightIcon className="h-8 w-8" />
+            <ChevronRightIcon className="h-8 w-8" />
           ) : (
-            <ChevronDoubleLeftIcon className="h-8 w-8" />
+            <ChevronLeftIcon className="h-8 w-8" />
           )}
         </button>
         {/* Tooltip */}


### PR DESCRIPTION
Add `2xl` breakpoints for when the browser window is larger than 96rem (1536px) the width of the Left column is 400px and the right column is in the range of 400-450px.

I changed the chevron double right/left arrows that control the collapse and expanding of the right column to a _single_ chevron arrow, as I think it is more of a match to the simple styled icons in the app.