### PR TITLE
Collections styles

### DIFF
--- a/src/components/leftColumn/collectionsArea/CollectionManager.tsx
+++ b/src/components/leftColumn/collectionsArea/CollectionManager.tsx
@@ -243,12 +243,14 @@ export default function CollectionManager() {
     newName: string
   ) => {
     // Check if collection is ingested
-    const collection = collections.find(c => c.id === collectionId);
-    
+    const collection = collections.find((c) => c.id === collectionId);
+
     if (!collection?.isIngested) {
       // For non-ingested collections, rename locally only
       renameCollection(collectionId, newName);
-      setStatusMessage(`Collection renamed to "${newName}" (will sync after ingestion).`);
+      setStatusMessage(
+        `Collection renamed to "${newName}" (will sync after ingestion).`
+      );
       setTimeout(() => setStatusMessage(null), 3000);
       return;
     }
@@ -368,11 +370,6 @@ export default function CollectionManager() {
                         ) : (
                           <span className="flex-1 font-medium">
                             {collection.name}
-                            {activeCollectionId === collection.id && (
-                              <span className="ml-2 text-xs bg-selectedBlue px-2 py-1 rounded text-primaryWhite">
-                                ACTIVE
-                              </span>
-                            )}
                           </span>
                         )}
 

--- a/src/components/leftColumn/collectionsArea/CollectionManager.tsx
+++ b/src/components/leftColumn/collectionsArea/CollectionManager.tsx
@@ -377,12 +377,6 @@ export default function CollectionManager() {
                           {collection.files.length} file
                           {collection.files.length !== 1 ? "s" : ""}
                         </span>
-
-                        {collection.isIngested && (
-                          <span className="text-xs bg-green-600 px-2 py-1 rounded text-primaryWhite">
-                            INGESTED
-                          </span>
-                        )}
                       </div>
 
                       <div className="flex items-center gap-1">


### PR DESCRIPTION
I deleted the little ACTIVE and INGESTED flags next to the collection name, as it looked odd and seemed unnecessary. 

This is what it now looks like with 
_Collection 1_ having been **ingested**, but **not selected**,
_two fidles_ been **ingested** and **selected**,
_Collection 3_ **not ingested** and **not selected**.

<img width="346" alt="New collection ingested style" src="https://github.com/user-attachments/assets/c6b03774-20a6-42c8-ac72-50f789078f0f" />

You can only select a non ingested collection by clicking the _Ingest Collection_ button on a non-ingested file.
