### PR TITLE
Isolate ingest endpoint

### DIFF
--- a/fastapi-backend/config/shared.py
+++ b/fastapi-backend/config/shared.py
@@ -1,0 +1,85 @@
+# fastapi-backend/config/shared.py
+"""
+Shared configuration and session management to avoid circular imports
+"""
+import os
+import time
+from typing import Dict, Any
+from chromadb.config import Settings
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_community.chat_models import ChatOllama
+from langchain.chains import ConversationalRetrievalChain
+from langchain.prompts import PromptTemplate
+from file_handlers.file_tools import USER_DIRS
+
+# Global session storage
+SESSIONS: Dict[str, Dict[str, Any]] = {}
+
+def initialize_session(session_id: str):
+    """Initialize a new session with a default empty collection"""
+    if session_id not in SESSIONS:
+        # Create default empty vectorstore
+        embeddings = HuggingFaceEmbeddings(
+            model_name="sentence-transformers/all-MiniLM-L6-v2", 
+            model_kwargs={'trust_remote_code': True}
+        )
+        
+        # Create collection directory for default collection
+        default_collection_dir = os.path.join(USER_DIRS, session_id, "collections", "default")
+        os.makedirs(default_collection_dir, exist_ok=True)
+        
+        # Create empty vectorstore
+        default_vectorstore = Chroma(
+            embedding_function=embeddings,
+            persist_directory=default_collection_dir
+        )
+        
+        # Create LLM and chatbot chain for default collection
+        llm = ChatOllama(model="llama3.1", temperature=0)
+        qa_prompt = PromptTemplate(
+            input_variables=["context", "question"],
+            template="You are a helpful AI assistant. Use the following context to answer the question if available, otherwise answer based on your general knowledge:\n\nContext: {context}\n\nQuestion: {question}\n\nAnswer:"
+        )
+        
+        # Create retriever (will be empty initially)
+        retriever = default_vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 2})
+        
+        # Create chain
+        chain = ConversationalRetrievalChain.from_llm(
+            llm=llm, 
+            retriever=retriever, 
+            return_source_documents=True,
+            combine_docs_chain_kwargs={"prompt": qa_prompt},
+            verbose=True
+        )
+        
+        SESSIONS[session_id] = {
+            "collections": {
+                "default": {
+                    "vectorstore": default_vectorstore,
+                    "name": "Default Chat",
+                    "files": [],
+                    "created_at": time.time(),
+                    "embedding_model": "sentence-transformers/all-MiniLM-L6-v2"
+                }
+            },
+            "active_collection_id": "default",
+            "history": [],
+            "chain": chain
+        }
+        print(f"DEBUG: Initialized new session {session_id} with default collection")
+
+# Chroma settings - move these from main.py
+chroma_settings = Settings(
+    chroma_db_impl="duckdb+parquet",
+    persist_directory="./chroma_db",
+    anonymized_telemetry=False,
+)
+
+# HNSW metadata - move this from main.py  
+hnsw_metadata = {
+    "hnsw:space": "cosine",
+    "hnsw:construction_ef": 100,
+    "hnsw:M": 16,
+}

--- a/fastapi-backend/dependencies/llm.py
+++ b/fastapi-backend/dependencies/llm.py
@@ -1,4 +1,4 @@
-# dependencies/llm.py
+# fastapi-backend/dependencies/llm.py
 import ollama
 # will configure llm to users choices, default is llama3.1
 def get_llm():

--- a/fastapi-backend/dependencies/vectorstore.py
+++ b/fastapi-backend/dependencies/vectorstore.py
@@ -2,6 +2,8 @@
 from fastapi import Body, Request, Depends, HTTPException
 from rag_calls.models import SingleRagRequest
 # from main import VECTOR_STORES
+from config.shared import SESSIONS
+
 
 
 def get_vectorstore(payload: SingleRagRequest = Body(...)):

--- a/fastapi-backend/dependencies/vectorstore.py
+++ b/fastapi-backend/dependencies/vectorstore.py
@@ -1,4 +1,4 @@
-# dependencies/vectorstore.py
+# fastapi-backend/dependencies/vectorstore.py
 from fastapi import Body, Request, Depends, HTTPException
 from rag_calls.models import SingleRagRequest
 # from main import VECTOR_STORES

--- a/fastapi-backend/ingest/ingest_route.py
+++ b/fastapi-backend/ingest/ingest_route.py
@@ -8,19 +8,19 @@ from typing import List
 import pandas as pd
 from fastapi import File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
-from langchain.document_loaders import PyMuPDFLoader
-from langchain.embeddings import HuggingFaceEmbeddings
+from langchain_community.document_loaders import PyMuPDFLoader
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_community.chat_models import ChatOllama
 from langchain.schema import Document
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.vectorstores import Chroma
-from langchain.llms import ChatOllama
 from langchain.chains import ConversationalRetrievalChain
 from langchain.prompts import PromptTemplate
 
 # Import from their original locations
 from utils import clean_dataframe
 from file_handlers.file_tools import USER_DIRS
-from main import SESSIONS, initialize_session, chroma_settings, hnsw_metadata
+from config.shared import SESSIONS, initialize_session, chroma_settings, hnsw_metadata
 
 
 async def ingest_collection(

--- a/fastapi-backend/ingest/ingest_route.py
+++ b/fastapi-backend/ingest/ingest_route.py
@@ -1,0 +1,165 @@
+import os
+import time
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+from fastapi import File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import JSONResponse
+from langchain.document_loaders import PyMuPDFLoader
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.schema import Document
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Chroma
+from langchain.llms import ChatOllama
+from langchain.chains import ConversationalRetrievalChain
+from langchain.prompts import PromptTemplate
+
+# Import from their original locations
+from utils import clean_dataframe
+from file_handlers.file_tools import USER_DIRS
+from main import SESSIONS, initialize_session, chroma_settings, hnsw_metadata
+
+
+async def ingest_collection(
+    request: Request,
+    files: List[UploadFile] = File(...),
+    collection_id: str = Form(...),
+    collection_name: str = Form(...),
+    embedding_model: str = Form("sentence-transformers/all-MiniLM-L6-v2"),
+):
+    """
+    Create a new vectorstore for a specific collection.
+    Each collection gets its own isolated vectorstore.
+    """
+    session_id = request.state.session_id
+    
+    # Initialize session if needed
+    initialize_session(session_id)
+    
+    # Create collection-specific directory
+    collection_dir = os.path.join(USER_DIRS, session_id, "collections", collection_id)
+    os.makedirs(collection_dir, exist_ok=True)
+    
+    # Process files and create documents
+    all_docs = []
+    file_info_list = []
+    
+    for upload in files:
+        ext = Path(upload.filename).suffix.lower()
+        metadata = {"source": upload.filename, "filetype": ext}
+        
+        # Store file info for frontend
+        file_info = {
+            "name": upload.filename,
+            "type": ext.lstrip('.'), 
+            "size": upload.size if hasattr(upload, 'size') else 0,
+            "dateCreated": time.strftime("%m/%d/%Y")
+        }
+        file_info_list.append(file_info)
+        
+        # Handle different file types
+        if ext == ".csv":
+            df = pd.read_csv(BytesIO(await upload.read()))
+            df = clean_dataframe(df)
+            for _, row in df.iterrows():
+                text = ", ".join(f"{col}: {row[col]}" for col in df.columns)
+                doc = Document(page_content=text, metadata=metadata)
+                all_docs.append(doc)
+                
+        elif ext in {".xlsx", ".xls"}:
+            df = pd.read_excel(BytesIO(await upload.read()), engine="openpyxl")
+            df = clean_dataframe(df)
+            for _, row in df.iterrows():
+                text = ", ".join(f"{col}: {row[col]}" for col in df.columns)
+                doc = Document(page_content=text, metadata=metadata)
+                all_docs.append(doc)
+                
+        elif ext == ".pdf":
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+            tmp.write(await upload.read())
+            tmp.flush()
+            docs = PyMuPDFLoader(tmp.name).load()
+            for doc in docs:
+                doc.metadata.update(metadata)
+                all_docs.append(doc)
+            os.unlink(tmp.name)  # Clean up temp file
+            
+        elif ext in {".png", ".jpg", ".jpeg", ".gif"}:
+            # TODO: implement image embedding with CLIP
+            continue
+    
+    if not all_docs:
+        raise HTTPException(400, "No processable files found")
+    
+    # Create embeddings and vectorstore
+    embeddings = HuggingFaceEmbeddings(
+        model_name=embedding_model, 
+        model_kwargs={'trust_remote_code': True}
+    )
+    
+    # Create text splitter
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=0)
+    split_docs = text_splitter.split_documents(all_docs)
+    
+    # Create vectorstore for this collection
+    vectorstore = Chroma.from_documents(
+        documents=split_docs,
+        embedding=embeddings,
+        persist_directory=collection_dir,
+        client_settings=chroma_settings,
+        collection_metadata=hnsw_metadata,
+    )
+    
+    # Store collection info in session
+    SESSIONS[session_id]["collections"][collection_id] = {
+        "vectorstore": vectorstore,
+        "name": collection_name,
+        "files": file_info_list,
+        "created_at": time.time(),
+        "embedding_model": embedding_model
+    }
+    
+    # Set as active collection
+    SESSIONS[session_id]["active_collection_id"] = collection_id
+    
+    # Automatically create a chatbot for this collection
+    try:
+        # Create LLM
+        llm = ChatOllama(model="llama3.1", temperature=0)
+        
+        # Create prompt template
+        qa_prompt = PromptTemplate(
+            input_variables=["context", "question"],
+            template="You are a helpful AI. Use the following context to answer the question:\n\nContext: {context}\n\nQuestion: {question}\n\nAnswer:"
+        )
+        
+        # Create retriever
+        retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 2})
+        
+        # Create chain
+        chain = ConversationalRetrievalChain.from_llm(
+            llm=llm, 
+            retriever=retriever, 
+            return_source_documents=True,
+            combine_docs_chain_kwargs={"prompt": qa_prompt},
+            verbose=True
+        )
+        
+        # Store chain in session
+        SESSIONS[session_id]["chain"] = chain
+        print(f"DEBUG: Chatbot automatically created for collection {collection_id} in session {session_id}")
+        
+    except Exception as e:
+        print(f"ERROR: Failed to create chatbot automatically: {str(e)}")
+        # Don't fail the ingestion if chatbot creation fails
+    
+    return JSONResponse({
+        "session_id": session_id,
+        "collection_id": collection_id,
+        "collection_name": collection_name,
+        "files_processed": len(files),
+        "chatbot_created": "chain" in SESSIONS[session_id] and SESSIONS[session_id]["chain"] is not None
+    })

--- a/fastapi-backend/ingest/ingest_route.py
+++ b/fastapi-backend/ingest/ingest_route.py
@@ -19,7 +19,6 @@ from langchain.prompts import PromptTemplate
 
 # Import from their original locations
 from utils import clean_dataframe
-from file_handlers.file_tools import USER_DIRS
 from config.shared import SESSIONS, initialize_session, chroma_settings, hnsw_metadata
 
 
@@ -38,6 +37,9 @@ async def ingest_collection(
     
     # Initialize session if needed
     initialize_session(session_id)
+    
+    # Import USER_DIRS here to avoid circular imports
+    from file_handlers.file_tools import USER_DIRS
     
     # Create collection-specific directory
     collection_dir = os.path.join(USER_DIRS, session_id, "collections", collection_id)
@@ -109,8 +111,6 @@ async def ingest_collection(
         documents=split_docs,
         embedding=embeddings,
         persist_directory=collection_dir,
-        client_settings=chroma_settings,
-        collection_metadata=hnsw_metadata,
     )
     
     # Store collection info in session

--- a/fastapi-backend/main.py
+++ b/fastapi-backend/main.py
@@ -8,7 +8,6 @@ import shutil
 from typing import Dict, List, Optional, Literal
 import logging
 import re
-import datetime
 
 
 import pandas as pd
@@ -16,7 +15,7 @@ import numpy as np
 
 from fastapi import FastAPI, File, Request, UploadFile, Form, Depends, HTTPException, Body, APIRouter
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi.responses import JSONResponse, Response
 from contextlib import asynccontextmanager
 api_router = APIRouter()
 
@@ -24,7 +23,6 @@ api_router = APIRouter()
 from utils import create_table_summary_prompt, segment_and_export_tables, clean_dataframe, get_magic_wand_suggestions
 
 from pydantic import BaseModel
-import base64
 from io import BytesIO
 
 import uvicorn
@@ -33,7 +31,7 @@ import tempfile
 import zipfile
 from io import BytesIO
 
-# from langchain_community.document_loaders import PyMuPDFLoader
+
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_core.documents import Document
@@ -42,6 +40,7 @@ from langchain_community.chat_models import ChatOllama
 from langchain.prompts import PromptTemplate
 from chromadb.config import Settings as ChromaSettings # hyperparams
 from langchain_community.vectorstores import Chroma # hyperparams
+import textwrap
 
 import asyncio, yaml
 from mcp_agent.app import MCPApp
@@ -154,78 +153,12 @@ app.add_middleware(
 # Add to config
 SESSION_TIMEOUT = 86400  # 24 hours in seconds
 
-# Chroma / HNSW Defaults for hyperparams
-# chroma_settings = ChromaSettings(anonymized_telemetry=False)
-# hnsw_metadata = {
-#     "hnsw:space": "cosine",
-#     "hnsw:search_ef": 150,
-# }
-
 # Session tracking dict
 ACTIVE_SESSIONS = {}  # {session_id: last_activity_timestamp}
 
-# UPLOAD_DIR = "uploaded_files"
+
 OUTPUT_DIR = "output_tables"
-# os.makedirs(UPLOAD_DIR, exist_ok=True)
 os.makedirs(OUTPUT_DIR, exist_ok=True)
-
-
-
-# Session structure for collection-based vectorstores
-# SESSIONS = {}
-
-# def initialize_session(session_id: str):
-#     """Initialize a new session with a default empty collection"""
-#     if session_id not in SESSIONS:
-#         # Create default empty vectorstore
-#         embeddings = HuggingFaceEmbeddings(
-#             model_name="sentence-transformers/all-MiniLM-L6-v2", 
-#             model_kwargs={'trust_remote_code': True}
-#         )
-        
-#         # Create collection directory for default collection
-#         default_collection_dir = os.path.join(USER_DIRS, session_id, "collections", "default")
-#         os.makedirs(default_collection_dir, exist_ok=True)
-        
-#         # Create empty vectorstore
-#         default_vectorstore = Chroma(
-#             embedding_function=embeddings,
-#             persist_directory=default_collection_dir
-#         )
-        
-#         # Create LLM and chatbot chain for default collection
-#         llm = ChatOllama(model="llama3.1", temperature=0)
-#         qa_prompt = PromptTemplate(
-#             input_variables=["context", "question"],
-#             template="You are a helpful AI assistant. Use the following context to answer the question if available, otherwise answer based on your general knowledge:\n\nContext: {context}\n\nQuestion: {question}\n\nAnswer:"
-#         )
-        
-#         # Create retriever (will be empty initially)
-#         retriever = default_vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 2})
-        
-#         # Create chain
-#         chain = ConversationalRetrievalChain.from_llm(
-#             llm=llm, 
-#             retriever=retriever, 
-#             return_source_documents=True,
-#             combine_docs_chain_kwargs={"prompt": qa_prompt},
-#             verbose=True
-#         )
-        
-#         SESSIONS[session_id] = {
-#             "collections": {
-#                 "default": {
-#                     "vectorstore": default_vectorstore,
-#                     "name": "Default Chat",
-#                     "files": [],
-#                     "created_at": time.time(),
-#                     "embedding_model": "sentence-transformers/all-MiniLM-L6-v2"
-#                 }
-#             },
-#             "active_collection_id": "default",
-#             "history": [],
-#             "chain": chain
-#         }
 
 # MCP server var init
 mcp_server = None

--- a/fastapi-backend/main.py
+++ b/fastapi-backend/main.py
@@ -61,6 +61,7 @@ from pdf_handlers.pdf_tools import router as pdf_router
 from image_handlers.image_tools import router as image_router
 from table_handlers.table_tools import router as table_router
 
+from ingest.ingest_route import ingest_collection
 
 from pydantic import ValidationError
 
@@ -567,146 +568,14 @@ async def get_chat_response(
 
 
 @app.post("/api/ingest")
-async def ingest_collection(
+async def ingest_collection_endpoint(
     request: Request,
     files: List[UploadFile] = File(...),
     collection_id: str = Form(...),
     collection_name: str = Form(...),
     embedding_model: str = Form("sentence-transformers/all-MiniLM-L6-v2"),
 ):
-    """
-    Create a new vectorstore for a specific collection.
-    Each collection gets its own isolated vectorstore.
-    """
-    session_id = request.state.session_id
-    
-    # Initialize session if needed
-    initialize_session(session_id)
-    
-    # Create collection-specific directory
-    collection_dir = os.path.join(USER_DIRS, session_id, "collections", collection_id)
-    os.makedirs(collection_dir, exist_ok=True)
-    
-    # Process files and create documents
-    all_docs = []
-    file_info_list = []
-    
-    for upload in files:
-        ext = Path(upload.filename).suffix.lower()
-        metadata = {"source": upload.filename, "filetype": ext}
-        
-        # Store file info for frontend
-        file_info = {
-            "name": upload.filename,
-            "type": ext.lstrip('.'), 
-            "size": upload.size if hasattr(upload, 'size') else 0,
-            "dateCreated": time.strftime("%m/%d/%Y")
-        }
-        file_info_list.append(file_info)
-        
-        # Handle different file types
-        if ext == ".csv":
-            df = pd.read_csv(BytesIO(await upload.read()))
-            df = clean_dataframe(df)
-            for _, row in df.iterrows():
-                text = ", ".join(f"{col}: {row[col]}" for col in df.columns)
-                doc = Document(page_content=text, metadata=metadata)
-                all_docs.append(doc)
-                
-        elif ext in {".xlsx", ".xls"}:
-            df = pd.read_excel(BytesIO(await upload.read()), engine="openpyxl")
-            df = clean_dataframe(df)
-            for _, row in df.iterrows():
-                text = ", ".join(f"{col}: {row[col]}" for col in df.columns)
-                doc = Document(page_content=text, metadata=metadata)
-                all_docs.append(doc)
-                
-        elif ext == ".pdf":
-            tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
-            tmp.write(await upload.read())
-            tmp.flush()
-            docs = PyMuPDFLoader(tmp.name).load()
-            for doc in docs:
-                doc.metadata.update(metadata)
-                all_docs.append(doc)
-            os.unlink(tmp.name)  # Clean up temp file
-            
-        elif ext in {".png", ".jpg", ".jpeg", ".gif"}:
-            # TODO: implement image embedding with CLIP
-            continue
-    
-    if not all_docs:
-        raise HTTPException(400, "No processable files found")
-    
-    # Create embeddings and vectorstore
-    embeddings = HuggingFaceEmbeddings(
-        model_name=embedding_model, 
-        model_kwargs={'trust_remote_code': True}
-    )
-    
-    # Create text splitter
-    text_splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=0)
-    split_docs = text_splitter.split_documents(all_docs)
-    
-    # Create vectorstore for this collection
-    vectorstore = Chroma.from_documents(
-        documents=split_docs,
-        embedding=embeddings,
-        persist_directory=collection_dir,
-        client_settings=chroma_settings,
-        collection_metadata=hnsw_metadata,
-    )
-    
-    # Store collection info in session
-    SESSIONS[session_id]["collections"][collection_id] = {
-        "vectorstore": vectorstore,
-        "name": collection_name,
-        "files": file_info_list,
-        "created_at": time.time(),
-        "embedding_model": embedding_model
-    }
-    
-    # Set as active collection
-    SESSIONS[session_id]["active_collection_id"] = collection_id
-    
-    # Automatically create a chatbot for this collection
-    try:
-        # Create LLM
-        llm = ChatOllama(model="llama3.1", temperature=0)
-        
-        # Create prompt template
-        qa_prompt = PromptTemplate(
-            input_variables=["context", "question"],
-            template="You are a helpful AI. Use the following context to answer the question:\n\nContext: {context}\n\nQuestion: {question}\n\nAnswer:"
-        )
-        
-        # Create retriever
-        retriever = vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 2})
-        
-        # Create chain
-        chain = ConversationalRetrievalChain.from_llm(
-            llm=llm, 
-            retriever=retriever, 
-            return_source_documents=True,
-            combine_docs_chain_kwargs={"prompt": qa_prompt},
-            verbose=True
-        )
-        
-        # Store chain in session
-        SESSIONS[session_id]["chain"] = chain
-        print(f"DEBUG: Chatbot automatically created for collection {collection_id} in session {session_id}")
-        
-    except Exception as e:
-        print(f"ERROR: Failed to create chatbot automatically: {str(e)}")
-        # Don't fail the ingestion if chatbot creation fails
-    
-    return JSONResponse({
-        "session_id": session_id,
-        "collection_id": collection_id,
-        "collection_name": collection_name,
-        "files_processed": len(files),
-        "chatbot_created": "chain" in SESSIONS[session_id] and SESSIONS[session_id]["chain"] is not None
-    })
+    return await ingest_collection(request, files, collection_id, collection_name, embedding_model)
 
 
 # Collection Management Endpoints

--- a/fastapi-backend/main.py
+++ b/fastapi-backend/main.py
@@ -33,10 +33,9 @@ import tempfile
 import zipfile
 from io import BytesIO
 
-from langchain_community.document_loaders import PyMuPDFLoader
+# from langchain_community.document_loaders import PyMuPDFLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.vectorstores import Chroma
-from langchain.embeddings import HuggingFaceEmbeddings
+from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_core.documents import Document
 from langchain.chains import ConversationalRetrievalChain, LLMChain
 from langchain_ollama import ChatOllama
@@ -62,6 +61,7 @@ from image_handlers.image_tools import router as image_router
 from table_handlers.table_tools import router as table_router
 
 from ingest.ingest_route import ingest_collection
+from config.shared import SESSIONS, initialize_session, chroma_settings, hnsw_metadata
 
 from pydantic import ValidationError
 
@@ -155,11 +155,11 @@ app.add_middleware(
 SESSION_TIMEOUT = 86400  # 24 hours in seconds
 
 # Chroma / HNSW Defaults for hyperparams
-chroma_settings = ChromaSettings(anonymized_telemetry=False)
-hnsw_metadata = {
-    "hnsw:space": "cosine",
-    "hnsw:search_ef": 150,
-}
+# chroma_settings = ChromaSettings(anonymized_telemetry=False)
+# hnsw_metadata = {
+#     "hnsw:space": "cosine",
+#     "hnsw:search_ef": 150,
+# }
 
 # Session tracking dict
 ACTIVE_SESSIONS = {}  # {session_id: last_activity_timestamp}
@@ -172,7 +172,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 
 # Session structure for collection-based vectorstores
-SESSIONS = {}
+# SESSIONS = {}
 
 def initialize_session(session_id: str):
     """Initialize a new session with a default empty collection"""

--- a/fastapi-backend/main.py
+++ b/fastapi-backend/main.py
@@ -38,7 +38,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_core.documents import Document
 from langchain.chains import ConversationalRetrievalChain, LLMChain
-from langchain_ollama import ChatOllama
+from langchain_community.chat_models import ChatOllama
 from langchain.prompts import PromptTemplate
 from chromadb.config import Settings as ChromaSettings # hyperparams
 from langchain_community.vectorstores import Chroma # hyperparams
@@ -174,58 +174,58 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 # Session structure for collection-based vectorstores
 # SESSIONS = {}
 
-def initialize_session(session_id: str):
-    """Initialize a new session with a default empty collection"""
-    if session_id not in SESSIONS:
-        # Create default empty vectorstore
-        embeddings = HuggingFaceEmbeddings(
-            model_name="sentence-transformers/all-MiniLM-L6-v2", 
-            model_kwargs={'trust_remote_code': True}
-        )
+# def initialize_session(session_id: str):
+#     """Initialize a new session with a default empty collection"""
+#     if session_id not in SESSIONS:
+#         # Create default empty vectorstore
+#         embeddings = HuggingFaceEmbeddings(
+#             model_name="sentence-transformers/all-MiniLM-L6-v2", 
+#             model_kwargs={'trust_remote_code': True}
+#         )
         
-        # Create collection directory for default collection
-        default_collection_dir = os.path.join(USER_DIRS, session_id, "collections", "default")
-        os.makedirs(default_collection_dir, exist_ok=True)
+#         # Create collection directory for default collection
+#         default_collection_dir = os.path.join(USER_DIRS, session_id, "collections", "default")
+#         os.makedirs(default_collection_dir, exist_ok=True)
         
-        # Create empty vectorstore
-        default_vectorstore = Chroma(
-            embedding_function=embeddings,
-            persist_directory=default_collection_dir
-        )
+#         # Create empty vectorstore
+#         default_vectorstore = Chroma(
+#             embedding_function=embeddings,
+#             persist_directory=default_collection_dir
+#         )
         
-        # Create LLM and chatbot chain for default collection
-        llm = ChatOllama(model="llama3.1", temperature=0)
-        qa_prompt = PromptTemplate(
-            input_variables=["context", "question"],
-            template="You are a helpful AI assistant. Use the following context to answer the question if available, otherwise answer based on your general knowledge:\n\nContext: {context}\n\nQuestion: {question}\n\nAnswer:"
-        )
+#         # Create LLM and chatbot chain for default collection
+#         llm = ChatOllama(model="llama3.1", temperature=0)
+#         qa_prompt = PromptTemplate(
+#             input_variables=["context", "question"],
+#             template="You are a helpful AI assistant. Use the following context to answer the question if available, otherwise answer based on your general knowledge:\n\nContext: {context}\n\nQuestion: {question}\n\nAnswer:"
+#         )
         
-        # Create retriever (will be empty initially)
-        retriever = default_vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 2})
+#         # Create retriever (will be empty initially)
+#         retriever = default_vectorstore.as_retriever(search_type="similarity", search_kwargs={"k": 2})
         
-        # Create chain
-        chain = ConversationalRetrievalChain.from_llm(
-            llm=llm, 
-            retriever=retriever, 
-            return_source_documents=True,
-            combine_docs_chain_kwargs={"prompt": qa_prompt},
-            verbose=True
-        )
+#         # Create chain
+#         chain = ConversationalRetrievalChain.from_llm(
+#             llm=llm, 
+#             retriever=retriever, 
+#             return_source_documents=True,
+#             combine_docs_chain_kwargs={"prompt": qa_prompt},
+#             verbose=True
+#         )
         
-        SESSIONS[session_id] = {
-            "collections": {
-                "default": {
-                    "vectorstore": default_vectorstore,
-                    "name": "Default Chat",
-                    "files": [],
-                    "created_at": time.time(),
-                    "embedding_model": "sentence-transformers/all-MiniLM-L6-v2"
-                }
-            },
-            "active_collection_id": "default",
-            "history": [],
-            "chain": chain
-        }
+#         SESSIONS[session_id] = {
+#             "collections": {
+#                 "default": {
+#                     "vectorstore": default_vectorstore,
+#                     "name": "Default Chat",
+#                     "files": [],
+#                     "created_at": time.time(),
+#                     "embedding_model": "sentence-transformers/all-MiniLM-L6-v2"
+#                 }
+#             },
+#             "active_collection_id": "default",
+#             "history": [],
+#             "chain": chain
+#         }
 
 # MCP server var init
 mcp_server = None

--- a/fastapi-backend/rag_calls/api_rag_calls.py
+++ b/fastapi-backend/rag_calls/api_rag_calls.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Request, Body, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from rag_calls.models import SingleRagRequest, DescriptionResponse, TitleResponse, KeywordsResponse 
 from dependencies.llm import get_llm
-from dependencies.vectorstore import get_vectorstore
+from config.shared import get_vectorstore
 from pydantic import ValidationError
 from starlette.concurrency import run_in_threadpool
 


### PR DESCRIPTION
I've refactored where 
```
SESSIONS, 
intialize_sessions(session_id) ,  
get_vectorstore(payload), 
chroma_settings, 
hnsw_metadata
```
 to all exist in the new `fastapi-backend/config/shared`.
 
Also, the ingest route now lives in its own own ingest folder and its own file `ingest_route.py`.

I removed everything that is in shared from `main.py`

This should keep us from getting circular import errors in the future. 

The file structure of everything I touched,
```
fastapi-backend/
├── main.py                           # Main FastAPI app (updated imports, removed ingest route)
├── config/
│   ├── __init__.py                   # New: Empty file to make config a package
│   └── shared.py                     # New: Shared SESSIONS, initialize_session, chroma_settings, etc.
├── ingest/
│   └── ingest_route.py               # New: Extracted /api/ingest route functionality
├── dependencies/
│   ├── llm.py                        # Existing: LLM dependency functions
│   └── vectorstore.py                # Updated: Now imports from config.shared instead of main
├── rag_calls/
│   ├── api_rag_calls.py              # Updated: Now 
```